### PR TITLE
갤러리 기능 개선 및 확장

### DIFF
--- a/src/main/java/org/younginhambak/backend/gallery/controller/PhotoController.java
+++ b/src/main/java/org/younginhambak/backend/gallery/controller/PhotoController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.younginhambak.backend.gallery.dto.PhotoCreateBatchRequest;
 import org.younginhambak.backend.gallery.dto.PhotoCreateRequest;
 import org.younginhambak.backend.gallery.dto.PhotoDetailResponse;
 import org.younginhambak.backend.gallery.dto.PhotoUpdateRequest;
@@ -36,6 +37,13 @@ public class PhotoController {
   public Long createPhoto(@RequestBody PhotoCreateRequest createRequest) {
     log.info("POST /api/v1/photos : {}", createRequest);
     return photoService.createPhoto(createRequest);
+  }
+
+  @ResponseStatus(HttpStatus.CREATED)
+  @PostMapping("/batch")
+  public List<Long> createPhotos(@RequestBody PhotoCreateBatchRequest createBatchRequest) {
+    log.info("POST /api/v1/photos/batch : {}", createBatchRequest);
+    return photoService.createPhotos(createBatchRequest);
   }
 
   @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/org/younginhambak/backend/gallery/controller/PhotoController.java
+++ b/src/main/java/org/younginhambak/backend/gallery/controller/PhotoController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import org.younginhambak.backend.gallery.dto.PhotoCreateBatchRequest;
-import org.younginhambak.backend.gallery.dto.PhotoCreateRequest;
-import org.younginhambak.backend.gallery.dto.PhotoDetailResponse;
-import org.younginhambak.backend.gallery.dto.PhotoUpdateRequest;
+import org.younginhambak.backend.gallery.dto.*;
 import org.younginhambak.backend.gallery.service.PhotoService;
 
 import java.util.List;
@@ -27,9 +24,11 @@ public class PhotoController {
   }
 
   @GetMapping
-  public List<PhotoDetailResponse> readPhotos() {
-    log.info("GET /api/v1/photos");
-    return photoService.readPhotos();
+  public List<PhotoDetailResponse> searchPhotos(@ModelAttribute PhotoSearchRequest searchRequest) {
+    log.info("GET /api/v1/photos?");
+    log.info("title = {}", searchRequest.getTitle());
+    log.info("tags = {}", searchRequest.getTags());
+    return photoService.readPhotos(searchRequest);
   }
 
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/org/younginhambak/backend/gallery/controller/PhotoController.java
+++ b/src/main/java/org/younginhambak/backend/gallery/controller/PhotoController.java
@@ -41,7 +41,7 @@ public class PhotoController {
 
   @ResponseStatus(HttpStatus.CREATED)
   @PostMapping("/batch")
-  public List<Long> createPhotos(@RequestBody PhotoCreateBatchRequest createBatchRequest) {
+  public List<Long> createPhotoBatch(@RequestBody PhotoCreateBatchRequest createBatchRequest) {
     log.info("POST /api/v1/photos/batch : {}", createBatchRequest);
     return photoService.createPhotos(createBatchRequest);
   }
@@ -60,5 +60,12 @@ public class PhotoController {
   public void deletePhoto(@PathVariable Long photoId) {
     log.info("DELETE /api/v1/photos/{}", photoId);
     photoService.deletePhoto(photoId);
+  }
+
+
+  @DeleteMapping("/batch")
+  public void deletePhotoBatch(@RequestBody List<Long> photoIds) {
+    log.info("DELETE /api/v1/photos/batch : {}", photoIds);
+    photoService.deletePhotos(photoIds);
   }
 }

--- a/src/main/java/org/younginhambak/backend/gallery/dto/PhotoCreateBatchRequest.java
+++ b/src/main/java/org/younginhambak/backend/gallery/dto/PhotoCreateBatchRequest.java
@@ -1,0 +1,52 @@
+package org.younginhambak.backend.gallery.dto;
+
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class PhotoCreateBatchRequest {
+  @NotNull
+  private Long creatorMemberId;
+
+  @NotNull
+  @Size(min = 1)
+  private List<Long> fileIds;
+
+  @NotNull
+  private List<String> commonTagNames;
+
+  @NotNull
+  @Size(min = 1)
+  private List<PhotoData> photos;
+
+  @AssertTrue
+  public boolean validateSameSize() {
+    return fileIds.size() == photos.size();
+  }
+
+  @Data
+  public static class PhotoData {
+
+    @NotBlank
+    @Size(min = 3, max = 30)
+    private String title;
+
+    @Size(max = 300)
+    private String description;
+
+    @Size(max = 30)
+    private String photographer;
+
+    @Past
+    private LocalDateTime takenAt;
+
+    @NotNull
+    private Long fileId;
+  }
+}
+

--- a/src/main/java/org/younginhambak/backend/gallery/dto/PhotoSearchRequest.java
+++ b/src/main/java/org/younginhambak/backend/gallery/dto/PhotoSearchRequest.java
@@ -1,0 +1,29 @@
+package org.younginhambak.backend.gallery.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PhotoSearchRequest {
+  @NotNull
+  @Size(min = 3, max = 30)
+  @Builder.Default
+  private String title = "";
+
+  @NotNull
+  @Builder.Default
+  private List<Long> tags = List.of();
+
+  @NotNull
+  @Builder.Default
+  private String sort = "created";
+}

--- a/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepository.java
+++ b/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepository.java
@@ -13,6 +13,8 @@ public interface PhotoRepository {
 
   Optional<Photo> findById(Long id);
 
+  List<Photo> findByIdIn(List<Long> ids);
+
   List<Photo> findByTitle(String title);
 
   List<Photo> findAll();

--- a/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepository.java
+++ b/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepository.java
@@ -18,5 +18,7 @@ public interface PhotoRepository {
   List<Photo> findByTitle(String title);
 
   List<Photo> findAll();
+
+  List<Photo> searchByCondition(String title, List<Long> tagIds, String sort);
 }
 

--- a/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepository.java
+++ b/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepository.java
@@ -9,6 +9,8 @@ public interface PhotoRepository {
 
   void save(Photo photo);
 
+  void saveAll(List<Photo> photos);
+
   Optional<Photo> findById(Long id);
 
   List<Photo> findByTitle(String title);

--- a/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepositoryImpl.java
+++ b/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepositoryImpl.java
@@ -1,9 +1,14 @@
 package org.younginhambak.backend.gallery.repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.younginhambak.backend.gallery.entity.Photo;
+import org.younginhambak.backend.gallery.entity.QPhoto;
+import org.younginhambak.backend.gallery.entity.QPhotoTag;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +18,7 @@ import java.util.Optional;
 public class PhotoRepositoryImpl implements PhotoRepository {
 
   private final EntityManager em;
+  private final JPAQueryFactory queryFactory;
 
   @Override
   public void save(Photo photo) {
@@ -50,5 +56,31 @@ public class PhotoRepositoryImpl implements PhotoRepository {
   public List<Photo> findAll() {
     return em.createQuery("select p from Photo p", Photo.class)
             .getResultList();
+  }
+
+  @Override
+  public List<Photo> searchByCondition(String title, List<Long> tagIds, String sort) {
+    QPhoto photo = QPhoto.photo;
+    QPhotoTag photoTag = QPhotoTag.photoTag;
+
+    JPAQuery<Photo> query = queryFactory
+            .selectDistinct(photo)
+            .from(photo)
+            .orderBy(photo.takenAt.desc());
+
+    BooleanBuilder builder = new BooleanBuilder();
+
+    if (!title.isBlank()) {
+      builder.and(photo.title.containsIgnoreCase(title));
+    }
+
+    if (!tagIds.isEmpty()) {
+      builder.and(photoTag.id.tagId.in(tagIds));
+      query.join(photo.photoTags, photoTag)
+              .groupBy(photo.id)
+              .having(photoTag.id.tagId.countDistinct().eq((long)tagIds.size()));
+    }
+
+    return query.where(builder).fetch();
   }
 }

--- a/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepositoryImpl.java
+++ b/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepositoryImpl.java
@@ -20,6 +20,11 @@ public class PhotoRepositoryImpl implements PhotoRepository {
   }
 
   @Override
+  public void saveAll(List<Photo> photos) {
+    photos.forEach(em::persist);
+  }
+
+  @Override
   public Optional<Photo> findById(Long id) {
     Photo photo = em.find(Photo.class, id);
     return Optional.ofNullable(photo);

--- a/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepositoryImpl.java
+++ b/src/main/java/org/younginhambak/backend/gallery/repository/PhotoRepositoryImpl.java
@@ -31,6 +31,14 @@ public class PhotoRepositoryImpl implements PhotoRepository {
   }
 
   @Override
+  public List<Photo> findByIdIn(List<Long> ids) {
+    String jsql = "select p from Photo p where p.id in :ids";
+    return em.createQuery(jsql, Photo.class)
+            .setParameter("ids", ids)
+            .getResultList();
+  }
+
+  @Override
   public List<Photo> findByTitle(String title) {
     String jsql = "select p from Photo p where p.title like :title";
     return em.createQuery(jsql, Photo.class)

--- a/src/main/java/org/younginhambak/backend/gallery/service/PhotoService.java
+++ b/src/main/java/org/younginhambak/backend/gallery/service/PhotoService.java
@@ -1,5 +1,6 @@
 package org.younginhambak.backend.gallery.service;
 
+import org.younginhambak.backend.gallery.dto.PhotoCreateBatchRequest;
 import org.younginhambak.backend.gallery.dto.PhotoCreateRequest;
 import org.younginhambak.backend.gallery.dto.PhotoDetailResponse;
 import org.younginhambak.backend.gallery.dto.PhotoUpdateRequest;
@@ -16,7 +17,8 @@ public interface PhotoService {
   List<PhotoTag> getPhotoTags(List<PhotoTagId> photoTagIds);
   PhotoDetailResponse readPhoto(Long photoId);
   List<PhotoDetailResponse> readPhotos();
-  Long createPhoto(PhotoCreateRequest createDto);
+  Long createPhoto(PhotoCreateRequest createRequest);
+  List<Long> createPhotos(PhotoCreateBatchRequest createBatchRequest);
   void updatePhoto(Long photoId, PhotoUpdateRequest updateDto);
   void deletePhoto(Long photoId);
 }

--- a/src/main/java/org/younginhambak/backend/gallery/service/PhotoService.java
+++ b/src/main/java/org/younginhambak/backend/gallery/service/PhotoService.java
@@ -1,9 +1,6 @@
 package org.younginhambak.backend.gallery.service;
 
-import org.younginhambak.backend.gallery.dto.PhotoCreateBatchRequest;
-import org.younginhambak.backend.gallery.dto.PhotoCreateRequest;
-import org.younginhambak.backend.gallery.dto.PhotoDetailResponse;
-import org.younginhambak.backend.gallery.dto.PhotoUpdateRequest;
+import org.younginhambak.backend.gallery.dto.*;
 import org.younginhambak.backend.gallery.entity.Photo;
 import org.younginhambak.backend.gallery.entity.PhotoTag;
 import org.younginhambak.backend.gallery.entity.PhotoTagId;
@@ -18,6 +15,7 @@ public interface PhotoService {
   List<PhotoTag> getPhotoTags(List<PhotoTagId> photoTagIds);
   PhotoDetailResponse readPhoto(Long photoId);
   List<PhotoDetailResponse> readPhotos();
+  List<PhotoDetailResponse> readPhotos(PhotoSearchRequest searchRequest);
   Long createPhoto(PhotoCreateRequest createRequest);
   List<Long> createPhotos(PhotoCreateBatchRequest createBatchRequest);
   void updatePhoto(Long photoId, PhotoUpdateRequest updateDto);

--- a/src/main/java/org/younginhambak/backend/gallery/service/PhotoService.java
+++ b/src/main/java/org/younginhambak/backend/gallery/service/PhotoService.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 public interface PhotoService {
   Optional<Photo> getPhoto(Long photoId);
+  List<Photo> getPhotos(List<Long> photoIds);
   List<Photo> getPhotoAll();
   List<PhotoTag> getPhotoTags(List<PhotoTagId> photoTagIds);
   PhotoDetailResponse readPhoto(Long photoId);
@@ -21,4 +22,5 @@ public interface PhotoService {
   List<Long> createPhotos(PhotoCreateBatchRequest createBatchRequest);
   void updatePhoto(Long photoId, PhotoUpdateRequest updateDto);
   void deletePhoto(Long photoId);
+  void deletePhotos(List<Long> photoIds);
 }

--- a/src/main/java/org/younginhambak/backend/gallery/service/PhotoServiceImpl.java
+++ b/src/main/java/org/younginhambak/backend/gallery/service/PhotoServiceImpl.java
@@ -8,10 +8,7 @@ import org.springframework.util.Assert;
 import org.younginhambak.backend.file.entity.DataFile;
 import org.younginhambak.backend.file.entity.PhotoFile;
 import org.younginhambak.backend.file.service.PhotoFileService;
-import org.younginhambak.backend.gallery.dto.PhotoCreateBatchRequest;
-import org.younginhambak.backend.gallery.dto.PhotoCreateRequest;
-import org.younginhambak.backend.gallery.dto.PhotoDetailResponse;
-import org.younginhambak.backend.gallery.dto.PhotoUpdateRequest;
+import org.younginhambak.backend.gallery.dto.*;
 import org.younginhambak.backend.gallery.entity.Photo;
 import org.younginhambak.backend.gallery.entity.PhotoTag;
 import org.younginhambak.backend.gallery.entity.PhotoTagId;
@@ -99,6 +96,32 @@ public class PhotoServiceImpl implements PhotoService {
               .updated(photo.getUpdated())
               .build();
     }).toList();
+  }
+
+  @Override
+  public List<PhotoDetailResponse> readPhotos(PhotoSearchRequest searchRequest) {
+    List<Photo> photos = photoRepository.searchByCondition(
+            searchRequest.getTitle(),
+            searchRequest.getTags(),
+            searchRequest.getSort()
+    );
+
+    return photos.stream()
+            .map(photo -> {
+              URL downloadUrl = photoFileService.generateDownloadUrl(photo.getFile().getFileKey(), photo.getFile().getFileName());
+              return PhotoDetailResponse.builder()
+                      .id(photo.getId())
+                      .title(photo.getTitle())
+                      .description(photo.getDescription())
+                      .photographer(photo.getPhotographer())
+                      .takenAt(photo.getTakenAt())
+                      .tagNames(photo.getTagNames())
+                      .fileUrl(downloadUrl)
+                      .created(photo.getCreated())
+                      .updated(photo.getUpdated())
+                      .build();
+            })
+            .toList();
   }
 
   @Override

--- a/src/main/java/org/younginhambak/backend/gallery/service/PhotoServiceImpl.java
+++ b/src/main/java/org/younginhambak/backend/gallery/service/PhotoServiceImpl.java
@@ -72,6 +72,7 @@ public class PhotoServiceImpl implements PhotoService {
             .title(photo.getTitle())
             .description(photo.getDescription())
             .photographer(photo.getPhotographer())
+            .takenAt(photo.getTakenAt())
             .tagNames(photo.getTagNames())
             .fileUrl(downloadUrl)
             .created(photo.getCreated())

--- a/src/main/java/org/younginhambak/backend/gallery/service/PhotoServiceImpl.java
+++ b/src/main/java/org/younginhambak/backend/gallery/service/PhotoServiceImpl.java
@@ -48,6 +48,13 @@ public class PhotoServiceImpl implements PhotoService {
   }
 
   @Override
+  public List<Photo> getPhotos(List<Long> photoIds) {
+    List<Photo> photos = photoRepository.findByIdIn(photoIds);
+    Assert.isTrue(photos.size() == photoIds.size(), "조회하려는 photo ids 중에 존재하지 않는 record의 id가 있습니다.");
+    return photos;
+  }
+
+  @Override
   public List<Photo> getPhotoAll() {
     return photoRepository.findAll();
   }
@@ -175,6 +182,13 @@ public class PhotoServiceImpl implements PhotoService {
   public void deletePhoto(Long photoId) {
     Photo photo = getPhoto(photoId).orElseThrow();
     photo.delete();
+  }
+
+  @Override
+  @Transactional
+  public void deletePhotos(List<Long> photoIds) {
+    List<Photo> photos = getPhotos(photoIds);
+    photos.forEach(Photo::delete);
   }
 
   private List<PhotoTag> getOrCreatePhotoTags(List<String> tagNames) {


### PR DESCRIPTION
## 변경 사항 요약
갤러리 기능에 대한 핵심 API 구현 및 버그 수정을 완료했습니다:

1. **사진 검색 기능 구현** (`GET /api/v1/photos`)
   - 제목 및 태그 기반 검색 기능 추가
   - 검색 조건 조합으로 필터링 가능

2. **사진 일괄 등록 기능** (`POST /api/v1/photos/batch`)
   - 다수의 사진을 한 번에 등록할 수 있는 API 추가
   - 클라이언트 요청 최적화를 위한 배치 처리 구현

3. **사진 일괄 삭제 기능** (`DELETE /api/v1/photos/batch`)
   - 다수의 사진을 한 번에 삭제할 수 있는 API 추가
   - ID 목록을 통한 효율적인 삭제 기능 구현

4. **버그 수정**
   - `GET /api/v1/photos/{id}` API에서 takenAt 필드가 누락되는 오류 수정
   - PhotoServiceImpl.readPhoto 메서드에서 응답 DTO에 촬영 날짜 정보가 제대로 포함되지 않던 문제 해결

## API 상세 정보
- `GET /api/v1/photos?title=검색어&tags=태그1,태그2`: 제목 및 태그 기반 검색
- `POST /api/v1/photos/batch`: 여러 사진 메타데이터를 한 번에 등록
- `DELETE /api/v1/photos/batch`: ID 목록을 통한 여러 사진 일괄 삭제